### PR TITLE
fix: server crash when requesting invalid hero id

### DIFF
--- a/src/rest/controllers/Heroes.ts
+++ b/src/rest/controllers/Heroes.ts
@@ -31,8 +31,9 @@ export async function getHeroById(req: Request, res: Response) {
 
     if (!hero) {
       res.status(404).send('not found');
+    } else {
+      res.send(hero);
     }
-    res.send(hero);
   } catch (e) {
     res.status(404).send(e.message);
   }


### PR DESCRIPTION
## Ticket

N/A

## Description

Currently, when requesting `GET /heroes/random-invalid-hero-id`, entire REST server crashes due to server headers' issue.

Stacktrace:
```bash
> $ npm run start:rest                                                                                  

> new-recru-api@1.0.0 start:rest /Users/adrian/Projects/heroes-api
> ts-node ./src/server-rest.ts

Server is listening on http://localhost:4000
Error [ERR_HTTP_HEADERS_SENT]: Cannot set headers after they are sent to the client
    at new NodeError (node:internal/errors:259:15)
    at ServerResponse.setHeader (node:_http_outgoing:563:11)
    at ServerResponse.header (/Users/adrian/Projects/heroes-api/node_modules/express/lib/response.js:771:10)
    at ServerResponse.send (/Users/adrian/Projects/heroes-api/node_modules/express/lib/response.js:170:12)
    at /Users/adrian/Projects/heroes-api/src/rest/controllers/Heroes.ts:37:21
    at Generator.next (<anonymous>)
    at fulfilled (/Users/adrian/Projects/heroes-api/src/rest/controllers/Heroes.ts:4:58)
    at processTicksAndRejections (node:internal/process/task_queues:93:5)
```

This PR fixes this issue.
